### PR TITLE
Drop python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py27, py35, py36, py37, flake8
+envlist = py35, py36, py37, flake8
 
 [travis]
 python =
-    2.7: py27
     3.5: py35
     3.6: py36
     3.7: py37


### PR DESCRIPTION
Actually just disable CI test for this version.